### PR TITLE
Detect node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,8 @@
 > Babel preset for all es2015 plugins needed with latest stable node.
 
 ## Install
-
-#### Node 6
 ```sh
-$ npm install --save-dev babel-preset-es2015-node@6
-```
-#### Node 5
-```sh
-$ npm install --save-dev babel-preset-es2015-node@5
-```
-#### Node 4
-```sh
-$ npm install --save-dev babel-preset-es2015-node@4
+$ npm install --save-dev babel-preset-es2015-node
 ```
 
 ## Usage

--- a/index.js
+++ b/index.js
@@ -1,12 +1,23 @@
-module.exports = {
-  plugins: [
+var semver = require("semver");
+
+var pluginsList = [
+  require("babel-plugin-transform-es2015-modules-commonjs")
+];
+
+if (semver.lt(process.version, '6.0.0')) {
+  pluginsList.push(
     require("babel-plugin-transform-es2015-destructuring"),
     require("babel-plugin-transform-es2015-function-name"),
-    require("babel-plugin-transform-es2015-modules-commonjs"),
     require("babel-plugin-transform-es2015-parameters"),
     require("babel-plugin-transform-es2015-shorthand-properties"),
-    require("babel-plugin-transform-es2015-spread"),
     require("babel-plugin-transform-es2015-sticky-regex"),
-    require("babel-plugin-transform-es2015-unicode-regex"),
-  ]
+    require("babel-plugin-transform-es2015-unicode-regex"));
+}
+
+if (semver.lt(process.version, '5.0.0')) {
+  pluginsList.push(require("babel-plugin-transform-es2015-spread"));
+}
+
+module.exports = {
+  plugins: pluginsList
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-es2015-node",
-  "version": "4.0.2",
+  "version": "6.0.1",
   "description": "Babel preset for all es2015 plugins needed with latest stable node.",
   "author": "Ryan Tsao <ryan.j.tsao@gmail.com>",
   "homepage": "https://babeljs.io/",
@@ -18,6 +18,7 @@
     "babel-plugin-transform-es2015-shorthand-properties": "6.x",
     "babel-plugin-transform-es2015-spread": "6.x",
     "babel-plugin-transform-es2015-sticky-regex": "6.x",
-    "babel-plugin-transform-es2015-unicode-regex": "6.x"
+    "babel-plugin-transform-es2015-unicode-regex": "6.x",
+    "semver": "5.1.0"
   }
 }


### PR DESCRIPTION
# Detect node version and return the appropriate transformers

This change allows for consumers to only depend on the lastest version of this preset for whatever (supported) version of Node they might be using.
## Motivation

To improve QoL for both the maintainer...
- one branch to rule them all
- one readme to tackle
- one version to publish

...and consumers of this package
- Ability to test the same changes on CI-setups with different versions of node.
- Allows to deploy the same project to heterogeneous environments
- Requires one less thing to worry about when jumping to a new major version

Feedback is hugely appreciated and please don't hesitate to reject this PR if this is not the path you want this package to go.

Thanks for the good work and have a nice day.
