### PR TITLE
Use loose dependency on semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "babel-plugin-transform-es2015-spread": "6.x",
     "babel-plugin-transform-es2015-sticky-regex": "6.x",
     "babel-plugin-transform-es2015-unicode-regex": "6.x",
-    "semver": "5.1.0"
+    "semver": "5.x"
   }
 }


### PR DESCRIPTION
@rtsao currently there's a hard dependency lock on `semver==5.1.0`, this PR makes it loose just like the other dependencies, so it can be updated independently
